### PR TITLE
Fix broken behaviour of fullscreen social demo

### DIFF
--- a/src/components/demo/DemoPlayer/SocialDemo.jsx
+++ b/src/components/demo/DemoPlayer/SocialDemo.jsx
@@ -13,6 +13,9 @@ const SocialDemo = ({vertId, adBlocker, subformat, context, ...params}) => {
 	// Adblock active? Show a warning.
 	if (adBlocker) return adBlockerAlert;
 
+	// allow independently overriding code and data servers
+	const forceServerType = params.dataServer || params.forceServerType;
+
 	// If no app or context specified, default to Instagram Stories & set URL to match
 	if (!subformat || !context) {
 		let {search, hash} = window.location;
@@ -29,14 +32,12 @@ const SocialDemo = ({vertId, adBlocker, subformat, context, ...params}) => {
 
 	// On mounting the SocialDemo element or changing advert ID, fetch the advert from the portal.
 	useEffect(() => {
-		const forceServerType = params.dataServer || params.forceServerType; // allow independently overriding code and data servers
 		getAdvertFromPortal({id: vertId, callback: setAdvert, status: params['gl.status'], forceServerType});
 	}, [vertId]);
 
 	// When the advert is loaded, get the advertiser as well - their info is needed to construct the fake interface
 	useEffect(() => {
-		const forceServerType = params.dataServer || params.forceServerType; // allow independently overriding code and data servers
-		advert && getVertiserFromPortal({id: advert.vertiser, callback: setAdvertiser});
+		advert && getVertiserFromPortal({id: advert.vertiser, callback: setAdvertiser, forceServerType});
 	}, [advert])
 
 	// If the advert ID, social platform, or context to simulate changes, return to the initial simulated feed
@@ -55,10 +56,20 @@ const SocialDemo = ({vertId, adBlocker, subformat, context, ...params}) => {
 		...params
 	};
 
+	const feedParams = {
+		advert: advert,
+		advertiser: advertiser,
+		showAd: () => setShowAd(true),
+		socialType: subformat,
+		socialContext: context,
+		muted: !params.unmuteSocial,
+		noInterface: params.noInterface
+	};
+
 	return (
 		<div className="ad-sizer portrait">
 			<div className="aspectifier" />
-			<MockFeed advert={advert} advertiser={advertiser} showAd={() => setShowAd(true)} socialType={subformat} socialContext={context} muted={!params.unmuteSocial}/>
+			<MockFeed {...feedParams} />
 			<div className={`social-ad fill-abs ${showAd ? 'show' : ''}`}>
 				{ showAd && advert ? <GoodLoopAd {...unitProps} /> : '' }
 			</div>

--- a/src/components/demo/FullscreenSocial.jsx
+++ b/src/components/demo/FullscreenSocial.jsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { getAdvertFromPortal, getVertiserFromPortal } from '../../utils';
 import MockFeed from './DemoPlayer/MockFeed';
+import SocialDemo from './DemoPlayer/SocialDemo';
 
 /**
  * Set font size on the containing div to 1% window.innerHeight
@@ -45,9 +46,9 @@ const FullscreenSocial = ({platform = 'instagram', context = 'stories', 'gl.vert
 		advert && getVertiserFromPortal({id: advert.vertiser, status, callback: setAdvertiser, forceServerType});
 	}, [advert])
 
-	const feed = advert && advertiser ? (
-		<MockFeed socialType={platform} socialContext={context} advert={advert} advertiser={advertiser} noInterface={noInterface} muted={!params.unmuteSocial}/>
-	) : null;
+	const feed = advert && advertiser ? [
+		<SocialDemo vertId={vertId} subformat={platform} context={context} noInterface={noInterface} {...params} />
+	 ] : null;
 
 	return (
 		<div id="fullscreen" className="portrait">
@@ -56,6 +57,6 @@ const FullscreenSocial = ({platform = 'instagram', context = 'stories', 'gl.vert
 			</div>
 		</div>
 	);
-}
+};
 
 export default FullscreenSocial;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ const baseConfig = {
 				}
 			}, {
 				test: /\.less$/,
-				use: [MiniCssExtractPlugin.loader, 'css-loader', 'less-loader'],
+				use: [MiniCssExtractPlugin.loader, {loader: 'css-loader', options: {url: false}}, 'less-loader'],
 			}
 		]
 	},


### PR DESCRIPTION
Fullscreen page now uses the whole SocialDemo component instead of MockFeed on its own - also enables recording transition to landing page in future