### PR TITLE
Feature/2023 10/display fromats

### DIFF
--- a/src/components/GoodLoopAd.jsx
+++ b/src/components/GoodLoopAd.jsx
@@ -2,6 +2,7 @@
 import { h, Fragment } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import { getAdvertFromAS, getNonce, getAdUrl } from '../utils';
+import {DEFAULT_AD} from './demo/constants';
 
 const loadingStyle = {
 	position: 'absolute',
@@ -51,10 +52,11 @@ const sizeFromUnit = (unitObj) => {
  * See VpaidAd.jsx for an adunit loader which inserts it using a VAST/VPAID player, instead of directly.
  */
 
-const GoodLoopAd = ({size, vertId, bare, extraNonce, refPolicy = 'no-referrer-when-downgrade', onUnitJson, ...params}) => {
+const GoodLoopAd = ({size, vertId, bare, extraNonce, refPolicy = 'no-referrer-when-downgrade', onUnitJson, useDefault, ...params}) => {
 	// there's a race condition when using legacy units that means variant.delivery / gl.delivery gets unset
 	// this stops the unit rendering TODO resolve later by merging params.variant on unit.json load - but for now shim it here
 	if (!params['gl.delivery']) params['gl.delivery'] = 'direct'; // don't overwrite delivery=app on social page!
+	if(useDefault) vertId = DEFAULT_AD;
 
 	// Load the ad
 	const [unitJson, setUnitJson] = useState(null); // Preloaded unit.json

--- a/src/components/demo/DemoPage.jsx
+++ b/src/components/demo/DemoPage.jsx
@@ -19,9 +19,9 @@ import DemoPicker from './DemoPicker';
  * - mobile-portrait
  * Given as a comma separated string as served by PropControl
  */
-const DemoPage = ({matches, path, url, noSocial, nosocial, hide, ...props}) => {
+const DemoPage = ({matches, path, url, noSocial, hide, ...props}) => {
 	// Allow any noSocial param at all, even an empty one, to work (unless value is "false")
-	const noSocialMerged = (noSocial !== 'false' && noSocial !== undefined) || (nosocial !== 'false' && nosocial !== undefined);
+	const noSocialMerged = (noSocial !== 'false' && noSocial !== undefined) || (noSocial !== 'false' && noSocial !== undefined);
 	const hides = hide ? hide.split(",") : [];
 
 	return <>

--- a/src/components/demo/DemoPlayer/DemoPlayer.jsx
+++ b/src/components/demo/DemoPlayer/DemoPlayer.jsx
@@ -65,6 +65,9 @@ const DemoPlayer = ({ format, device, 'gl.vert': vertId, url, matches, path, ...
 	// Add "autoplay on load" to params
 	params['gl.play'] = 'onload';
 
+	// keep note of original ad format
+	const adFormat = params['gl.format'] || "video";
+
 	// If missing vertId, use fallback ads for display format
 	let noVertId = !!vertId;
 
@@ -75,9 +78,9 @@ const DemoPlayer = ({ format, device, 'gl.vert': vertId, url, matches, path, ...
 	params.forceServerType = serverTypeForAd[vertId];
 
 	const ad = {
-		social: <SocialDemo vertId={vertId} adBlocker={adBlockDetected} {...params} />,
-		video: <GoodLoopAd vertId={vertId} size={sizes[device]} extraNonce={`${format}${device}`} onUnitJson={onUnitJson} {...params} />,
-		display: <DisplayDemo {...params} vertId={vertId} forceServerType={serverTypeForAd[vertId]} noVertId={noVertId} />
+		social: <SocialDemo vertId={vertId} adBlocker={adBlockDetected} {...params} useDefault={adFormat !== "social"}/>,
+		video: <GoodLoopAd vertId={vertId} size={sizes[device]} extraNonce={`${format}${device}`} onUnitJson={onUnitJson} {...params} useDefault={adFormat !== "video"}/>,
+		display: <DisplayDemo {...params} format={format} vertId={vertId} forceServerType={serverTypeForAd[vertId]} noVertId={noVertId} useDefault={adFormat !== "display"}/>
 	}[format];
 
 	// TODO we can add an extra block of description here, if needed.

--- a/src/components/demo/DemoPlayer/DisplayDemo.jsx
+++ b/src/components/demo/DemoPlayer/DisplayDemo.jsx
@@ -17,11 +17,13 @@ const AD_FALLBACK = {
 	responsive : TADG_DISPLAY_RESPONSIVE
 }
 
-const DisplayDemo = ({subformat: size, vertId, forceServerType, noVertId}) => {
+const DisplayDemo = ({subformat: size, vertId, forceServerType, noVertId, useDefault}) => {
 	let iframeUrl = `${getProtocol(forceServerType)}//${getPrefix(forceServerType)}as.good-loop.com/display/${vertId}/index.html`;
-	if(!noVertId) iframeUrl = `${getProtocol(forceServerType)}//${getPrefix(forceServerType)}demo.good-loop.com${AD_FALLBACK[size]}`;
+
+	// if no ad is selected or the ad isn't a display ad, show default
+	// TEMP HACK, just force it to use the old defaults as there's currently no actual existing 
+	if(true || !noVertId || useDefault) iframeUrl = `${getProtocol(forceServerType)}//${getPrefix(forceServerType)}demo.good-loop.com${AD_FALLBACK[size]}`;
 	
-	console.log(vertId, iframeUrl)
 	return (
 		<div className={`ad-sizer display banner-${size}`}>
 			<iframe src={iframeUrl} className="display-embed" width={STANDARD_SIZES[size][0]} height={STANDARD_SIZES[size][1]} />

--- a/src/style/ad-sizer.less
+++ b/src/style/ad-sizer.less
@@ -72,24 +72,36 @@
 		// 455px by 117px
 		iframe.display-embed {
 			transform: scale(46.9072164948%) translate(-56.3%, -61%);
+			@media (max-width: 576px) {
+				transform: scale(17%) translate(-245%, -261%);
+			}
 		}
 	}
 	&.banner-double-mpu {
 		// 164px by 329px
 		iframe.display-embed {
 			transform: scale(54.8333333333%) translate(-42%, -42%);
+			@media (max-width: 576px) {
+				transform: scale(20%) translate(-201%, -203%);
+			}
 		}
 	}
 	&.banner-leaderboard {
 		// 164px by 329px
 		iframe.display-embed {
 			transform: scale(0.621);
+			@media (max-width: 576px) {
+				transform: scale(25%) translate(-131%, -162%);
+			}
 		}
 	}
 	&.banner-responsive {
 		// 164px by 329px
 		iframe.display-embed {
 			transform: scale(0.621);
+			@media (max-width: 576px) {
+				transform: scale(20%) translate(-168%, -167%);
+			}
 		}
 	}
 }


### PR DESCRIPTION
most of a fix in & temp hack of a fix in to get this ready for release

Mobile display ads at least look supported now, before they had no restrictions ballooning out of their place. All formats for display ads now have default ads, though the leaderboard is one looks just "passable" and not "good" imo - it's something I want to come back to.

To stop stuff breaking, all display ad demos just use their default display ad. The reasons we were seeing stuff breaking was due to the fact that we now support display ads properly instead of the custom ones we did before. As a result, we're going to need to rethink how the demo page is supposed to work for them as right now the page expects a single ad. A display ad and a video ad should be distinct objects. For a given display ad, it should also only support a single format (mpu2, billboard, ...) so how are we going to - or even should we -  let the demo page swap between them?