### PR TITLE
Update webpack (and several more packages for fun) to resolve SSL-related compilation failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
     "jest": "^25.1.0",
     "jest-puppeteer": "^4.4.0",
     "less-loader": "^6.1.0",
-    "mini-css-extract-plugin": "^0.9.0",
+    "mini-css-extract-plugin": "^2.7.6",
     "node-fetch": "^2.6.1",
     "puppeteer": "^1.5.0",
     "reactstrap": "^8.1.1",
     "regenerator-runtime": "^0.13.3",
     "shelljs": "^0.8.3",
-    "webpack": "^4.41.2",
+    "webpack": "^5.89.0",
     "webpack-bundle-size-analyzer": "^3.1.0",
-    "webpack-cli": "^3.3.9"
+    "webpack-cli": "^5.1.4"
   },
   "dependencies": {
     "@babel/runtime": "^7.8.3",
@@ -31,8 +31,8 @@
     "@fortawesome/free-brands-svg-icons": "^5.11.2",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.7",
-    "preact": "^10.0.4",
-    "preact-router": "^3.1.0",
+    "preact": "^10.19.2",
+    "preact-router": "^4.1.2",
     "yargs": "^15.1.0"
   },
   "scripts": {


### PR DESCRIPTION
What it says on the tin - looks OK on local, also resolves a bundle of audit warnings.